### PR TITLE
Various fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ build/
 .idea/jarRepositories.xml
 .idea/compiler.xml
 .idea/libraries/
+.idea/checkstyle-idea.xml
 *.iws
 *.iml
 *.ipr

--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -10,9 +10,9 @@ import com.github.ajalt.mordant.rendering.Whitespace
 import com.github.ajalt.mordant.terminal.Terminal
 import com.vdurmont.semver4j.Semver
 import org.rauschig.jarchivelib.ArchiverFactory
-import java.io.File
 import java.net.URL
 import java.nio.file.Files
+import kotlin.io.path.createDirectories
 import kotlin.io.path.exists
 import kotlin.system.exitProcess
 
@@ -115,8 +115,6 @@ class InstallSolver : CliktCommand(name = "install") {
     private fun installSolver(solver: RemoteSolver, solverVersion: RemoteSolverVersion) {
         val tempDir = Files.createTempDirectory("download_$NAME")
         val url = URL(solverVersion.currentDownloadUrl)
-        val name = File(url.path).name
-        val localArchive = tempDir.resolve(name)
         val installationPath = getInstallationPath(solver, solverVersion)
 
         if (installationPath.exists()) {
@@ -127,16 +125,24 @@ class InstallSolver : CliktCommand(name = "install") {
 
         t.info("Installing to $installationPath")
 
-        downloadFile(url, localArchive)
+        // may change the localArchive filename if the connection is redirected
+        val localPath = downloadFile(url, tempDir)
+        val name = localPath.fileName.toString()
 
         try {
             t.info("Unpacking archive to $installationPath")
-            ArchiverFactory.createArchiver(localArchive.toFile())
-                ?.extract(localArchive.toFile(), installationPath.toFile())
-        } catch (_: java.lang.IllegalArgumentException) {
-            val target = installationPath.resolve(name)
-            t.info("Downloaded is an executable. Just copy it to $target")
-            Files.copy(localArchive, target)
+            ArchiverFactory.createArchiver(localPath.toFile())
+                ?.extract(localPath.toFile(), installationPath.toFile())
+        } catch (ex : Exception) {
+            when(ex) {
+                is java.lang.IllegalArgumentException, is java.io.IOException -> {
+                    val target = installationPath.resolve(name)
+                    t.info("Downloaded is an executable. Just copy it to $target")
+                    installationPath.createDirectories()
+                    Files.copy(localPath, target)
+                }
+                else -> throw ex
+            }
         }
 
         t.info("Register solver locally.")

--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -50,8 +50,8 @@ class UpdateRemoteRepository : CliktCommand(name = "update") {
         }
 
         val remote = readRemoteRepository()
-        val curVersion = Semver(VERSION)
-        val latestVersion = Semver(remote.latestVersion)
+        val curVersion = Semver(VERSION, Semver.SemverType.LOOSE)
+        val latestVersion = Semver(remote.latestVersion, Semver.SemverType.LOOSE)
 
         if (latestVersion > curVersion) {
             t.warning("A new version ${remote.latestVersion} (current: $curVersion) is available for download.")

--- a/src/main/kotlin/model.kt
+++ b/src/main/kotlin/model.kt
@@ -56,14 +56,25 @@ val CONFIG by lazy {
     }
 }
 
+val DATA_HOME: Path by lazy {
+    val s = System.getenv("XDG_DATA_HOME")
+    if (s == null) {
+        val home = System.getenv("HOME")
+        // if not set, use default value as defined in standard:
+        // https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html#variables
+        Paths.get(home, ".local", "share")
+    } else {
+        Paths.get(s)
+    }
+}
 
 @Serializable
 data class Config(
     val repositoryUrl: String = "https://raw.githubusercontent.com/wadoon/key-smtmgr/main/repo.json",
-    val installationPath: String = "\$XDG_DATA_PATH/key-smtmgr",
+    val installationDirname: String = "key-smtmgr",
     val repositoryCache: String = "repository.cache.json"
 ) {
-    val installationPathFile: Path by lazy { Paths.get(installationPath) }
+    val installationPathFile: Path by lazy { DATA_HOME.resolve(installationDirname) }
     val localInformationFile: Path by lazy { installationPathFile.resolve("info.json") }
     val repositoryCacheFile: Path by lazy { CONFIG_HOME.resolve(repositoryCache) }
 }


### PR DESCRIPTION
Provides the following fixes:
* No more error by Semver due to missing patch number
* Use XDG_DATA_HOME instead of XDG_DATA_PATH (does not exist in standard), and use the correct default value
* In case of redirections, the filename is correctly determined now. This is needed for MathSAT, which has the following URL: `https://mathsat.fbk.eu/download.php?file=mathsat-5.6.7-linux-x86_64.tar.gz` (thus, the downloaded file always had the name `download.php`, which crashed the unpacker).